### PR TITLE
Update Admin.js

### DIFF
--- a/src/pages/Admin.js
+++ b/src/pages/Admin.js
@@ -6,7 +6,7 @@ function Admin(props) {
   const { setAuthTokens } = useAuth();
 
   function logOut() {
-    setAuthTokens();
+    setAuthTokens("");
   }
 
   return (


### PR DESCRIPTION
When you call setAuthTokens() with an empty prop, the function will set the token as undefined, and generate an error when PrivateRoute will check the authTokens value